### PR TITLE
perf(response-transformer) accumulate chunks of response using table

### DIFF
--- a/kong/plugins/response-transformer/handler.lua
+++ b/kong/plugins/response-transformer/handler.lua
@@ -14,8 +14,11 @@ end
 
 function ResponseTransformerHandler:access(conf)
   ResponseTransformerHandler.super.access(self)
-  ngx.ctx.chunks = {}
-  ngx.ctx.chunk_number = 1
+
+  local ctx = ngx.ctx
+
+  ctx.rt_body_chunks = {}
+  ctx.rt_body_chunk_number = 1
 end
 
 function ResponseTransformerHandler:header_filter(conf)
@@ -26,14 +29,16 @@ end
 function ResponseTransformerHandler:body_filter(conf)
   ResponseTransformerHandler.super.body_filter(self)
 
+  local ctx = ngx.ctx
+
   if is_body_transform_set(conf) and is_json_body(ngx.header["content-type"]) then
     local chunk, eof = ngx.arg[1], ngx.arg[2]
     if eof then
-      local body = body_filter.transform_json_body(conf, table.concat(ngx.ctx.chunks))
+      local body = body_filter.transform_json_body(conf, table.concat(ctx.rt_body_chunks))
       ngx.arg[1] = body
     else
-      ngx.ctx.chunks[ngx.ctx.chunk_number] = chunk
-      ngx.ctx.chunk_number = ngx.ctx.chunk_number + 1
+      ctx.rt_body_chunks[ctx.rt_body_chunk_number] = chunk
+      ctx.rt_body_chunk_number = ctx.rt_body_chunk_number + 1
       ngx.arg[1] = nil
     end
   end

--- a/kong/plugins/response-transformer/handler.lua
+++ b/kong/plugins/response-transformer/handler.lua
@@ -4,6 +4,7 @@ local header_filter = require "kong.plugins.response-transformer.header_transfor
 
 local is_body_transform_set = header_filter.is_body_transform_set
 local is_json_body = header_filter.is_json_body
+local table_concat = table.concat
 
 local ResponseTransformerHandler = BasePlugin:extend()
 
@@ -33,7 +34,7 @@ function ResponseTransformerHandler:body_filter(conf)
     local ctx = ngx.ctx
     local chunk, eof = ngx.arg[1], ngx.arg[2]
     if eof then
-      local body = body_filter.transform_json_body(conf, table.concat(ctx.rt_body_chunks))
+      local body = body_filter.transform_json_body(conf, table_concat(ctx.rt_body_chunks))
       ngx.arg[1] = body
     else
       ctx.rt_body_chunks[ctx.rt_body_chunk_number] = chunk

--- a/kong/plugins/response-transformer/handler.lua
+++ b/kong/plugins/response-transformer/handler.lua
@@ -29,9 +29,8 @@ end
 function ResponseTransformerHandler:body_filter(conf)
   ResponseTransformerHandler.super.body_filter(self)
 
-  local ctx = ngx.ctx
-
   if is_body_transform_set(conf) and is_json_body(ngx.header["content-type"]) then
+    local ctx = ngx.ctx
     local chunk, eof = ngx.arg[1], ngx.arg[2]
     if eof then
       local body = body_filter.transform_json_body(conf, table.concat(ctx.rt_body_chunks))


### PR DESCRIPTION
Concatenate strings in buffer every time body_filter occurs
when receiving response from an upstream can lead strong overhead.
The right way would be to add chunks to a table, and do a concat
when eof occurs.

Programming in Lua - 11.6 – String Buffers:
https://www.lua.org/pil/11.6.html
Discussion in kong mailing list:
https://groups.google.com/forum/#!topic/konglayer/vWU5Y7Qsb_s